### PR TITLE
Fix candidate state comparison logic

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -72,7 +72,8 @@ def solve(
                 if candidate_state is None:
                     candidate_state = current_search_state
                 else:
-                    if current_search_state.state_game.segments < current_search_state.state_game.segments:
+                    # Choose the state with fewer segments as the better candidate
+                    if current_search_state.state_game.segments < candidate_state.state_game.segments:
                         candidate_state = current_search_state
             else:
                 if state_game.is_meaningful_state:


### PR DESCRIPTION
## Summary
- correct candidate state comparison in solver: use candidate state's segments instead of self-comparison

## Testing
- `python -m py_compile solver.py game.py excel_identifier.py`
- Attempted to run a sample solve, but missing dependencies (`numpy`). Tried installing `numpy pillow frozenlist` but network was blocked

------
https://chatgpt.com/codex/tasks/task_e_689598dd7b20832aac234eeafbc5bfd0