### PR TITLE
Fix typo in Game operations comment

### DIFF
--- a/game.py
+++ b/game.py
@@ -167,7 +167,7 @@ class Game:
                     temp_result = [OperationStepForward(src, dst)]
                     break
                 
-                # Empty desitnation
+                # Empty destination
                 if len(dst_group) == 0:
                     temp_result.append(OperationStepForward(src, dst))
                     continue


### PR DESCRIPTION
## Summary
- fix typo in Game.ops comment: `desitnation` -> `destination`

## Testing
- `python -m py_compile game.py`


------
https://chatgpt.com/codex/tasks/task_e_689599fcdf78832aae801cf1986fdfc3