### PR TITLE
Clarify uniform color move restriction

### DIFF
--- a/game.py
+++ b/game.py
@@ -158,7 +158,7 @@ class Game:
 
                 dst_group = self.groups[dst]
 
-                # Color mismatch
+                # Prevent moving an entire uniform-color group into an empty tube
                 if op_item.node_type == GameNodeType.KNOWN and len(set(node.color for node in src_group)) == 1 and len(dst_group) == 0:
                     continue
                     


### PR DESCRIPTION
## Summary
- clarify comment about avoiding moving an entire uniform-color group into an empty tube

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959a396a70832ab69681746317dcc7