### PR TITLE
feat: expose solver state snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An interactive web application for creating and solving Water Sort puzzles with 
 - **🎯 Smart Color Palette**: Automatic color management with remaining piece tracking
 - **🧠 Intelligent Solver**: TypeScript implementation matching the Python algorithm exactly
 - **📊 Solution Visualization**: Click on solution steps to see board states
+- **🖼️ State Snapshots**: Solver returns JSON snapshots of each state along the solution path for direct visualization
 - **🎮 Multiple Game Modes**: Normal, No-combo, Queue (FIFO) modes
 - **🎲 Random Puzzle Generator**: Create randomized puzzles for testing
 - **📱 Responsive Design**: Modern dark theme that works on all devices

--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -205,15 +205,16 @@ class WaterSortApp {
             
             const startState = new SearchState(game, []);
             const result = solve(startState, searchDepth, debugMode);
-            
+
             const formattedResult = {
                 success: result.success,
                 steps: result.steps,
                 searchedStates: result.searchedStates,
-                finalState: result.finalState
+                isPartialSolution: result.isPartialSolution,
+                stateSnapshots: result.stateSnapshots
             };
-            
-            this.solutionVisualizer.displaySolution(formattedResult, this.canvasEditor.getGameState());
+
+            this.solutionVisualizer.displaySolution(formattedResult);
             
         } catch (error) {
             console.error('Solver error:', error);


### PR DESCRIPTION
## Summary
- accumulate serialized game states during solving
- consume snapshots in visualization instead of recomputing states
- document snapshot availability and update app wiring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check` *(fails: TS errors in existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_6898098cf44c832a84891170e38739a4