### PR TITLE
Store full state sequence in SolveResult

### DIFF
--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -217,7 +217,7 @@ class WaterSortApp {
                 success: result.success,
                 steps: result.steps,
                 searchedStates: result.searchedStates,
-                finalState: result.finalState
+                finalState: result.allStates[result.allStates.length - 1]
             };
             
             this.solutionVisualizer.displaySolution(formattedResult, this.canvasEditor.getGameState()!);


### PR DESCRIPTION
## Summary
- track all visited game states in `SolveResult` via new `allStates` array
- derive state chains by replaying steps from the initial state, avoiding use of undo links
- clarify undo semantics by renaming `Game.prev` to `undoTargetState`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689984ffedb4832abf87ddc8da9e8a55