### PR TITLE
feat: introduce Color wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The application uses a carefully selected 12-color palette extracted from Excel:
 - **Canvas Rendering**: Smooth 60fps painting experience
 - **1:1 Python Port**: Identical algorithm to the original Python solver
 - **Event-Driven**: Reactive UI updates
+- **Branded Color Type**: Hex colors wrapped in a `Color` class for type safety
 
 ## 📝 Algorithm
 

--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -84,29 +84,29 @@ class WaterSortApp {
         // Create a simple solvable puzzle manually
         const board = this.canvasEditor.board;
         const palette = this.canvasEditor.palette;
-        
+
         // Use the first three colors from the palette
-        const color1 = palette[0].rgb; // Orange
-        const color2 = palette[1].rgb; // Red
-        const color3 = palette[2].rgb; // Blue
-        
+        const color1 = palette[0].color; // Orange
+        const color2 = palette[1].color; // Red
+        const color3 = palette[2].color; // Blue
+
         // Tube 1: Color1-Color1-Color2-Color2 (bottom to top)
-        board[0][0] = {type: NodeType.KNOWN, color: [...color1]};
-        board[0][1] = {type: NodeType.KNOWN, color: [...color1]};
-        board[0][2] = {type: NodeType.KNOWN, color: [...color2]};
-        board[0][3] = {type: NodeType.KNOWN, color: [...color2]};
-        
+        board[0][0] = {type: NodeType.KNOWN, color: new Color(color1.toString())};
+        board[0][1] = {type: NodeType.KNOWN, color: new Color(color1.toString())};
+        board[0][2] = {type: NodeType.KNOWN, color: new Color(color2.toString())};
+        board[0][3] = {type: NodeType.KNOWN, color: new Color(color2.toString())};
+
         // Tube 2: Color3-Color3-Color1-Color1
-        board[1][0] = {type: NodeType.KNOWN, color: [...color3]};
-        board[1][1] = {type: NodeType.KNOWN, color: [...color3]};
-        board[1][2] = {type: NodeType.KNOWN, color: [...color1]};
-        board[1][3] = {type: NodeType.KNOWN, color: [...color1]};
-        
-        // Tube 3: Color2-Color2-Color3-Color3  
-        board[2][0] = {type: NodeType.KNOWN, color: [...color2]};
-        board[2][1] = {type: NodeType.KNOWN, color: [...color2]};
-        board[2][2] = {type: NodeType.KNOWN, color: [...color3]};
-        board[2][3] = {type: NodeType.KNOWN, color: [...color3]};
+        board[1][0] = {type: NodeType.KNOWN, color: new Color(color3.toString())};
+        board[1][1] = {type: NodeType.KNOWN, color: new Color(color3.toString())};
+        board[1][2] = {type: NodeType.KNOWN, color: new Color(color1.toString())};
+        board[1][3] = {type: NodeType.KNOWN, color: new Color(color1.toString())};
+
+        // Tube 3: Color2-Color2-Color3-Color3
+        board[2][0] = {type: NodeType.KNOWN, color: new Color(color2.toString())};
+        board[2][1] = {type: NodeType.KNOWN, color: new Color(color2.toString())};
+        board[2][2] = {type: NodeType.KNOWN, color: new Color(color3.toString())};
+        board[2][3] = {type: NodeType.KNOWN, color: new Color(color3.toString())};
         
         // Tube 4: Empty
         for (let r = 0; r < 4; r++) {
@@ -146,7 +146,7 @@ class WaterSortApp {
                 const node = group[r];
                 if (node.nodeType === NodeType.KNOWN) {
                     // Known node with color
-                    const color = this.hexToRgb(node.color!);
+                    const color = node.color ? new Color(node.color.toString()) : null;
                     this.canvasEditor.board[c][r] = {type: NodeType.KNOWN, color: color};
                 } else if (node.nodeType === NodeType.UNKNOWN || node.nodeType === NodeType.UNKNOWN_REVEALED) {
                     // Unknown nodes - represent as empty in canvas (will be interpreted as unknown by syncToGameState)
@@ -165,12 +165,6 @@ class WaterSortApp {
         this.canvasEditor.syncToGameState();
     }
     
-    hexToRgb(hex: string): Color {
-        if (!hex) return [0, 0, 0];
-        const h = hex.replace('#', '');
-        return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
-    }
-
     solveGame(): void {
         const debugMode = (document.getElementById('debugMode') as HTMLInputElement).checked;
         const searchDepth = parseInt((document.getElementById('searchDepth') as HTMLInputElement).value);
@@ -196,7 +190,7 @@ class WaterSortApp {
                     else if (node.nodeType === NodeType.UNKNOWN_REVEALED) nodeType = NodeType.UNKNOWN_REVEALED;
                     else if (node.nodeType === NodeType.EMPTY) nodeType = NodeType.EMPTY;
 
-                    const color = node.color ? this.hexToRgb(node.color) : null;
+                    const color = node.color ? new Color(node.color.toString()) : null;
                     return new GameNode(nodeType, [groupIndex, nodeIndex], color);
                 })
             );

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -12,11 +12,14 @@ export enum GameMode {
     QUEUE = 2
 }
 
-export type Color = [number, number, number];
+// Branded wrapper around a hex color string for stronger typing
+export class Color extends String {
+    constructor(hex: string) { super(hex); }
+}
 
 export interface GameStateNode {
     nodeType: NodeType;
-    color: string | null;
+    color: Color | null;
     originalPos: [number, number];
 }
 
@@ -27,11 +30,11 @@ export interface GameState {
 
 export interface BoardCell {
     type: NodeType;
-    color: number[] | null;
+    color: Color | null;
 }
 
 export interface PaletteColor {
-    rgb: number[];
+    color: Color;
     target: number;
     remaining: number;
 }

--- a/src/ts/visualization.ts
+++ b/src/ts/visualization.ts
@@ -53,8 +53,8 @@ export class GameVisualizer {
                     ball.textContent = '?';
                     ball.title = 'Unknown Revealed';
                 } else if (node.color) {
-                    ball.style.backgroundColor = node.color;
-                    ball.title = node.color;
+                    ball.style.backgroundColor = node.color.toString();
+                    ball.title = node.color.toString();
                 }
                 
                 tube.appendChild(ball);
@@ -211,7 +211,7 @@ export class SolutionVisualizer {
                 for (let i = topBallIndex; i >= 0; i--) {
                     const node = srcGroup[i];
                     if (node.nodeType !== NodeType.EMPTY &&
-                        JSON.stringify(node.color) === JSON.stringify(ball.color)) {
+                        node.color?.toString() === ball.color?.toString()) {
                         ballsToMove.unshift(node);
                     } else {
                         break;


### PR DESCRIPTION
## Summary
- introduce branded `Color` class wrapping hex strings
- refactor game, editor, and app code to use `Color` objects and `.toString()` comparisons
- document `Color` usage in README

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899a71f6988832aa830593f01fcaad3