### PR TITLE
Fix undo visualization and add FastPriorityQueue types

### DIFF
--- a/src/ts/fastpriorityqueue.d.ts
+++ b/src/ts/fastpriorityqueue.d.ts
@@ -1,0 +1,10 @@
+declare module 'fastpriorityqueue' {
+    export default class FastPriorityQueue<T> {
+        constructor(comparator?: (a: T, b: T) => boolean);
+        add(item: T): boolean;
+        poll(): T | undefined;
+        peek(): T | undefined;
+        isEmpty(): boolean;
+    }
+}
+

--- a/src/ts/solver.ts
+++ b/src/ts/solver.ts
@@ -76,7 +76,7 @@ export function solve(startState: SearchState, depth = 8, debug = false, originS
 
 
     // Min-heap comparator on SearchState.value (lexicographic ascending)
-    const pq = new FastPriorityQueue<SearchState>((a, b) => {
+    const pq = new FastPriorityQueue<SearchState>((a: SearchState, b: SearchState): boolean => {
         const av = a.value, bv = b.value;
         for (let i = 0; i < Math.min(av.length, bv.length); i++) {
             if (av[i] !== bv[i]) return av[i] < bv[i];
@@ -121,7 +121,7 @@ export function solve(startState: SearchState, depth = 8, debug = false, originS
                 const ops = currentSearchState.path;
                 return {
                     success: true,
-                    steps: ops.map(op => op.toString()),
+                    steps: ops.map((op: StepOp | UndoOp) => op.toString()),
                     searchedStates: searchedStateCount,
                     allStates: buildStateChain(originState, ops)
                 };
@@ -165,10 +165,10 @@ export function solve(startState: SearchState, depth = 8, debug = false, originS
 
         const path = currentSearchState.path;
         discoveredDict.set(canonicalStateKey(stateGame), [stateGame, stateGame.undoCount]);
-        const ops = stateGame.ops();
+        const ops: (StepOp | UndoOp)[] = stateGame.ops();
 
         if (debug) {
-            console.log(`Available operations: ${ops.length}`, ops.map(op => op.toString()));
+            console.log(`Available operations: ${ops.length}`, ops.map((op: StepOp | UndoOp) => op.toString()));
         }
 
         for (const op of ops) {
@@ -177,14 +177,14 @@ export function solve(startState: SearchState, depth = 8, debug = false, originS
     }
 
     if (candidateState !== null) {
-        const ops = candidateState.path;
-        return {
-            success: true, // Changed: when unknown blocks present, finding revealing steps is success
-            steps: ops.map(op => op.toString()),
-            searchedStates: searchedStateCount,
-            allStates: buildStateChain(originState, ops),
-            isPartialSolution: true // Indicate this reveals unknowns rather than solves completely
-        };
+            const ops = candidateState.path;
+            return {
+                success: true, // Changed: when unknown blocks present, finding revealing steps is success
+                steps: ops.map((op: StepOp | UndoOp) => op.toString()),
+                searchedStates: searchedStateCount,
+                allStates: buildStateChain(originState, ops),
+                isPartialSolution: true // Indicate this reveals unknowns rather than solves completely
+            };
     }
 
     return {

--- a/src/ts/visualization.ts
+++ b/src/ts/visualization.ts
@@ -175,9 +175,22 @@ export class SolutionVisualizer {
 
         // Initialize undo count if not present
         if (!currentState.undoCount) currentState.undoCount = 5;
+        const undoStack: GameState[] = [];
 
         for (const step of steps) {
+            if (step === "Undo") {
+                const prev = undoStack.pop();
+                if (prev) {
+                    currentState = JSON.parse(JSON.stringify(prev));
+                }
+                currentState.undoCount = Math.max(0, (currentState.undoCount || 5) - 1);
+                reveals.push(null);
+                states.push(JSON.parse(JSON.stringify(currentState)) as GameState);
+                continue;
+            }
+
             const prevState: GameState = JSON.parse(JSON.stringify(currentState));
+            undoStack.push(prevState);
             // Apply the step to get the next state
             currentState = this.applyStepToState(currentState, step);
 
@@ -203,17 +216,10 @@ export class SolutionVisualizer {
 
 
     applyStepToState(state: GameState, stepStr: string): GameState {
-        // Parse step like "1 -> 2" or "Undo"
-        if (stepStr === "Undo") {
-            // Decrement undo count
-            const newState: GameState = JSON.parse(JSON.stringify(state));
-            newState.undoCount = Math.max(0, (newState.undoCount || 5) - 1);
-            return newState;
-        }
-        
+        // Parse step like "1 -> 2"
         const match = stepStr.match(/(\d+) -> (\d+)/);
         if (!match) return state;
-        
+
         const srcIndex = parseInt(match[1]) - 1;  // Convert to 0-based
         const dstIndex = parseInt(match[2]) - 1;
         
@@ -263,7 +269,7 @@ export class SolutionVisualizer {
                 }
             }
         }
-        
+
         return newState;
     }
 


### PR DESCRIPTION
## Summary
- handle `Undo` steps properly when reconstructing solution states
- add TypeScript types for FastPriorityQueue and tighten solver typings

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899b422057c832a949bd41a1e18fe00