### PR TITLE
feat: enforce immutability for game state

### DIFF
--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -7,13 +7,13 @@ import { GameVisualizer, SolutionVisualizer } from './visualization.ts';
 import { GameState, GameStateNode, NodeType, GameMode, Color } from './types.ts';
 
 function gameToGameState(game: Game): GameState {
-    const groups: GameStateNode[][] = game.groups.map(group =>
+    const groups = game.groups.map(group =>
         group.map(node => ({
             nodeType: node.type,
             color: node.color ? new Color(node.color.toString()) : null,
             originalPos: [node.pos[0], node.pos[1]] as [number, number]
         }))
-    );
+    ) as GameStateNode[][];
     return { groups, undoCount: game.undoCount };
 }
 
@@ -202,7 +202,7 @@ class WaterSortApp {
                     else if (node.nodeType === NodeType.EMPTY) nodeType = NodeType.EMPTY;
 
                     const color = node.color ? new Color(node.color.toString()) : null;
-                    return new GameNode(nodeType, [groupIndex, nodeIndex], color);
+                    return new GameNode(nodeType, [groupIndex, nodeIndex] as [number, number], color);
                 })
             );
             


### PR DESCRIPTION
## Summary
- make `GameNode` properties and `Game.groups` immutable
- rebuild arrays on apply/clone to avoid in-place mutation
- adjust app helpers to consume readonly structures

## Testing
- `npm run type-check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899bb274ac4832a866e04528fef2b9b