### PR TITLE
Normalize node tuples for frozenset hash

### DIFF
--- a/python_prototype/game.py
+++ b/python_prototype/game.py
@@ -311,7 +311,16 @@ class Game:
 
     @cached_property
     def _to_frozensets(self):
-        return frozenset(tuple(group) for group in self.groups)
+        processed_groups: list[tuple] = []
+        for group in self.groups:
+            processed_nodes = []
+            for node in group:
+                if node.node_type == GameNodeType.KNOWN:
+                    processed_nodes.append((node.node_type, node.color))
+                else:
+                    processed_nodes.append((node.node_type, node.color, node.original_pos))
+            processed_groups.append(tuple(processed_nodes))
+        return frozenset(processed_groups)
 
     @cached_property
     def _to_hashable(self):


### PR DESCRIPTION
## Summary
- include original positions in unknown node hashes
- ignore positions for known nodes when hashing

## Testing
- `pytest`
- `python -m py_compile python_prototype/game.py`


------
https://chatgpt.com/codex/tasks/task_e_6899bcf732e4832a8a500bf0b1d54ba8