### PR TITLE
Add puzzle JSON import/export

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,8 @@
                 <label>Undo Count <input id="undo" type="number" value="5" min="0" max="20"></label>
                 <button id="reset" class="secondary">Reset</button>
                 <button id="rand" class="secondary">Randomize</button>
+                <button id="copyJson" class="secondary">Copy JSON</button>
+                <button id="pasteJson" class="secondary">Paste JSON</button>
             </div>
             <div style="margin-top:10px"><canvas id="grid" width="300" height="300"></canvas></div>
 

--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -51,6 +51,20 @@ class WaterSortApp {
             this.canvasEditor.randomize();
         });
 
+        document.getElementById('copyJson')!.addEventListener('click', () => {
+            const json = this.canvasEditor.exportToJSON();
+            navigator.clipboard.writeText(json);
+        });
+
+        document.getElementById('pasteJson')!.addEventListener('click', async () => {
+            try {
+                const text = await navigator.clipboard.readText();
+                this.importFromJSON(text);
+            } catch (err) {
+                console.error('Failed to paste puzzle JSON', err);
+            }
+        });
+
         (document.getElementById('numcolors') as HTMLInputElement).addEventListener('input', (e: Event) => {
             const target = e.target as HTMLInputElement;
             this.canvasEditor.rebuildPalette(parseInt(target.value));
@@ -175,7 +189,16 @@ class WaterSortApp {
         this.canvasEditor.draw();
         this.canvasEditor.syncToGameState();
     }
-    
+
+    importFromJSON(json: string): void {
+        try {
+            const gameState = JSON.parse(json) as GameState;
+            this.setCanvasFromGameState(gameState);
+        } catch (err) {
+            console.error('Invalid puzzle JSON', err);
+        }
+    }
+
     solveGame(): void {
         const debugMode = (document.getElementById('debugMode') as HTMLInputElement).checked;
         const searchDepth = parseInt((document.getElementById('searchDepth') as HTMLInputElement).value);

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -314,4 +314,8 @@ export class CanvasEditor {
         }
         return { groups };
     }
+
+    exportToJSON(): string {
+        return JSON.stringify(this.toSolverFormat());
+    }
 }


### PR DESCRIPTION
## Summary
- support exporting puzzle state to JSON
- allow importing puzzle JSON into canvas editor
- add UI buttons to copy or paste puzzle JSON via clipboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6899bf657c9c832aa56a5229afb12d05