### PR TITLE
Add JSON puzzle loader and shared solver entry

### DIFF
--- a/python_prototype/excel_identifier.py
+++ b/python_prototype/excel_identifier.py
@@ -1,7 +1,6 @@
 import win32com.client
-from dataclasses import dataclass
-from game import Game, GameNode, GameNodeType, OperationStepForward, OperationUndo, visualize_game, GameOperation, GameMode
-from solver import SearchState, solve
+from game import Game, GameNode, GameNodeType, GameMode
+from solver_runner import solve_and_print
 
 BOUNDARY_COLOR = (0,0,0)
 EMPTY_COLOR = (255,255,255)
@@ -90,20 +89,4 @@ def read_current_excel_sheet() -> Game:
 
 if __name__ == "__main__":
     game = read_current_excel_sheet()
-    visualize_game(game).save("debug/input.png")
-    solved_state = solve(SearchState(game, []))
-
-    if solved_state.state_game.is_winning_state:
-        print(*solved_state.path, sep="\n")
-    else:
-        print("Follow the steps, update the blocks, and run again:")
-        for i, step in enumerate(solved_state.path, start=1):
-            new_game = game.apply_op(step)
-            print(step)
-            if new_game.unknown_revealed_count > game.unknown_revealed_count:
-                revealed_set = set(node[0].original_pos for node in new_game.unknown_revealed_nodes) - set(node[0].original_pos for node in game.unknown_revealed_nodes)
-                assert len(revealed_set) == 1
-                revealed = revealed_set.pop()
-                print(f"Update node at column {revealed[0] + 1}, row {revealed[1] + 1}")
-            game = new_game
-        visualize_game(game).save("final_state.png")
+    solve_and_print(game)

--- a/python_prototype/game.py
+++ b/python_prototype/game.py
@@ -333,7 +333,23 @@ class Game:
     def __eq__(self, other: Self) -> bool:
         return self._to_hashable() == other._to_hashable()
 
-def visualize_game(game: Game, scale:int = 20) -> Image:
+    def to_json(self) -> dict:
+        def node_to_dict(node: GameNode) -> dict:
+            data = {
+                "nodeType": node.node_type.value,
+                "originalPos": list(node.original_pos),
+            }
+            if node.node_type == GameNodeType.KNOWN and node.color is not None:
+                data["color"] = list(node.color)
+            return data
+
+        return {
+            "groups": [[node_to_dict(n) for n in g] for g in self.groups],
+            "undoCount": self.undo_count,
+        }
+
+
+def visualize_game(game: Game, scale: int = 20) -> Image:
     game_size = (game.group_capacity, len(game.groups))
     image_np = np.ones((*game_size, 3), dtype="u1") * 255
     for col, group in enumerate(game.groups):

--- a/python_prototype/json_identifier.py
+++ b/python_prototype/json_identifier.py
@@ -1,0 +1,64 @@
+import json
+import sys
+from typing import Union
+
+from game import Game, GameNode, GameNodeType
+from solver_runner import solve_and_print
+
+
+def rgb_to_hex(rgb: tuple[int, int, int]) -> str:
+    return "#%02x%02x%02x" % rgb
+
+
+def hex_to_rgb(color_str: str) -> tuple[int, int, int]:
+    color_str = color_str.lstrip('#')
+    if len(color_str) != 6:
+        raise ValueError(f"Invalid hex color: {color_str}")
+    return tuple(int(color_str[i:i+2], 16) for i in (0, 2, 4))
+
+
+def node_from_json(node_data: dict) -> GameNode:
+    node_type = GameNodeType(node_data["nodeType"])
+    pos = tuple(node_data["originalPos"])
+    color = None
+    if node_type == GameNodeType.KNOWN:
+        color_str = node_data.get("color")
+        if color_str is None:
+            raise ValueError("Known node missing color")
+        color = hex_to_rgb(color_str)
+    return GameNode(node_type, pos, color)
+
+
+def game_from_json(data: Union[str, dict]) -> Game:
+    if isinstance(data, str):
+        data = json.loads(data)
+    groups = []
+    for g in data["groups"]:
+        groups.append([node_from_json(n) for n in g])
+    undo = data.get("undoCount", 5)
+    return Game(groups, undo_count=undo)
+
+
+def game_to_json(game: Game) -> dict:
+    data = game.to_json()
+    for group in data["groups"]:
+        for node in group:
+            color = node.get("color")
+            if color is not None:
+                node["color"] = rgb_to_hex(tuple(color))
+    return data
+
+
+def read_json_file(path: str) -> Game:
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return game_from_json(data)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: json_identifier.py <puzzle.json>")
+        sys.exit(1)
+    game = read_json_file(sys.argv[1])
+    solve_and_print(game)
+

--- a/python_prototype/solver_runner.py
+++ b/python_prototype/solver_runner.py
@@ -1,0 +1,22 @@
+from game import Game, visualize_game
+from solver import SearchState, solve
+
+
+def solve_and_print(game: Game) -> None:
+    visualize_game(game).save("debug/input.png")
+    solved_state = solve(SearchState(game, []))
+    if solved_state.state_game.is_winning_state:
+        print(*solved_state.path, sep="\n")
+    else:
+        print("Follow the steps, update the blocks, and run again:")
+        for step in solved_state.path:
+            new_game = game.apply_op(step)
+            print(step)
+            if new_game.unknown_revealed_count > game.unknown_revealed_count:
+                revealed_set = set(n[0].original_pos for n in new_game.unknown_revealed_nodes) - \
+                               set(n[0].original_pos for n in game.unknown_revealed_nodes)
+                assert len(revealed_set) == 1
+                revealed = revealed_set.pop()
+                print(f"Update node at column {revealed[0] + 1}, row {revealed[1] + 1}")
+            game = new_game
+        visualize_game(game).save("final_state.png")


### PR DESCRIPTION
## Summary
- Move JSON parsing and color conversion helpers into `json_identifier.py`
- Add `Game.to_json` method and drop JSON utilities from `game.py`

## Testing
- `python -m py_compile game.py solver_runner.py json_identifier.py excel_identifier.py`
- `python json_identifier.py sample.json`


------
https://chatgpt.com/codex/tasks/task_e_6899be830240832a8b7390007c3c0fba