### PR TITLE
Fix JSON paste and include puzzle metadata

### DIFF
--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -41,16 +41,20 @@ class WaterSortApp {
         });
 
         document.getElementById('copyJson')!.addEventListener('click', () => {
-            const json = this.canvasEditor.exportToJSON();
+            const mode = Number((document.getElementById('mode') as HTMLInputElement).value) as GameMode;
+            const json = this.canvasEditor.exportToJSON(mode);
             navigator.clipboard.writeText(json);
         });
 
         document.getElementById('pasteJson')!.addEventListener('click', async () => {
+            let text = '';
             try {
-                const text = await navigator.clipboard.readText();
-                this.importFromJSON(text);
+                text = await navigator.clipboard.readText();
             } catch (err) {
-                console.error('Failed to paste puzzle JSON', err);
+                text = prompt('Paste puzzle JSON:') || '';
+            }
+            if (text) {
+                this.importFromJSON(text);
             }
         });
 
@@ -181,8 +185,17 @@ class WaterSortApp {
 
     importFromJSON(json: string): void {
         try {
-            const gameState = JSON.parse(json) as GameState;
-            this.setCanvasFromGameState(gameState);
+            const data = JSON.parse(json) as GameState & {cols?: number; rows?: number; mode?: GameMode};
+            if (typeof data.cols === 'number') {
+                (document.getElementById('cols') as HTMLInputElement).value = data.cols.toString();
+            }
+            if (typeof data.rows === 'number') {
+                (document.getElementById('rows') as HTMLInputElement).value = data.rows.toString();
+            }
+            if (typeof data.mode === 'number') {
+                (document.getElementById('mode') as HTMLInputElement).value = data.mode.toString();
+            }
+            this.setCanvasFromGameState(data);
         } catch (err) {
             console.error('Invalid puzzle JSON', err);
         }

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -1,6 +1,6 @@
 // Canvas-based game editor
 
-import { NodeType, GameState, GameStateNode, BoardCell, PaletteColor, Color } from './types.ts';
+import { NodeType, GameState, GameStateNode, BoardCell, PaletteColor, Color, GameMode } from './types.ts';
 
 export class CanvasEditor {
     canvas: HTMLCanvasElement;
@@ -315,7 +315,13 @@ export class CanvasEditor {
         return { groups };
     }
 
-    exportToJSON(): string {
-        return JSON.stringify(this.toSolverFormat());
+    exportToJSON(mode: GameMode): string {
+        const data = {
+            cols: this.W,
+            rows: this.H,
+            mode,
+            groups: this.toSolverFormat().groups
+        };
+        return JSON.stringify(data);
     }
 }


### PR DESCRIPTION
## Summary
- include columns, rows, and mode in exported puzzle JSON
- read pasted JSON from clipboard or prompt and restore metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899d179a94c832a9012bf9ffce0bfd9