### PR TITLE
Add Dockerfile for containerized build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use official Node.js LTS image
+FROM node:20-alpine
+
+# Create and set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source files
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Expose the development/preview port
+EXPOSE 3000
+
+# Run the built app with Vite preview
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs dependencies, builds the app, and serves the production build on port 3000

## Testing
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d551b8ac832a95378f36649a826a