### PR TITLE
Allow Docker image to run behind reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use official Node.js LTS image
 FROM node:20-alpine
 
+# Prevent Vite or other tools from trying to open a browser in the
+# container where no GUI is available
+ENV BROWSER=none
+
 # Create and set working directory
 WORKDIR /app
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -7,7 +7,14 @@ export default defineConfig({
     emptyOutDir: true
   },
   server: {
+    host: true,
     port: 3000,
-    open: true
+    open: false,
+    allowedHosts: 'all'
+  },
+  preview: {
+    host: true,
+    port: 3000,
+    allowedHosts: 'all'
   }
 })


### PR DESCRIPTION
## Summary
- disable browser launch in Docker image
- loosen Vite server/preview host restrictions and disable auto-open

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899e9c2aad8832a8bc73b253b610a1e