### PR TITLE
Add meta description for unknown cells

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Water Sort / Ball Sort puzzle solver that allows unknown cells">
     <title>Water Sort Puzzle Solver</title>
     <link rel="stylesheet" href="css/style.css">
 </head>


### PR DESCRIPTION
## Summary
- ensure meta description highlights that Water Sort / Ball Sort solver allows unknown cells in English only

## Testing
- `npm test` (fails: Missing script "test")
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899f46ddbc4832abe067cbab299c18d