### PR TITLE
Remove random puzzle feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ An interactive web application for creating and solving Water Sort puzzles with 
 - **🧠 Intelligent Solver**: TypeScript implementation matching the Python algorithm exactly
 - **📊 Solution Visualization**: Click on solution steps to see board states
 - **🎮 Multiple Game Modes**: Normal, No-combo, Queue (FIFO) modes
-- **🎲 Random Puzzle Generator**: Create randomized puzzles for testing
 - **📱 Responsive Design**: Modern dark theme that works on all devices
 
 ## 🚀 Quick Start
@@ -67,7 +66,7 @@ src/
 2. **Select colors**: Click color swatches in the palette
 3. **Paint**: Left-click to paint, right-click to erase
 4. **Manage colors**: Each swatch shows remaining pieces
-5. **Quick actions**: Use Reset or Randomize buttons
+5. **Quick actions**: Use the Reset button
 
 ### Solving Puzzles
 

--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,6 @@
                 </label>
                 <label>Undo Count <input id="undo" type="number" value="5" min="0" max="20"></label>
                 <button id="reset" class="secondary">Reset</button>
-                <button id="rand" class="secondary">Randomize</button>
                 <button id="copyJson" class="secondary">Copy JSON</button>
                 <button id="pasteJson" class="secondary">Paste JSON</button>
             </div>

--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -36,10 +36,6 @@ class WaterSortApp {
             this.canvasEditor.reset();
         });
 
-        document.getElementById('rand')!.addEventListener('click', () => {
-            this.canvasEditor.randomize();
-        });
-
         document.getElementById('copyJson')!.addEventListener('click', () => {
             const mode = Number((document.getElementById('mode') as HTMLInputElement).value) as GameMode;
             const json = this.canvasEditor.exportToJSON(mode);

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -211,40 +211,6 @@ export class CanvasEditor {
         this.syncToGameState();
     }
 
-    randomize(): void {
-        // Typical setup: fill N-2 tubes with H of each color
-        const n = Math.max(1, Math.min(this.W - 2, this.palette.length || Math.max(2, this.W - 2)));
-        if (!this.palette.length) this.rebuildPalette();
-        
-        this.board = this.createBoard(this.W, this.H);
-        for (let t = 0; t < n; t++) {
-            for (let r = 0; r < this.H; r++) {
-                this.board[t][r] = {type: NodeType.KNOWN, color: new Color(this.palette[t % this.palette.length].color.toString())};
-            }
-        }
-        
-        // Shuffle
-        for (let k = 0; k < 200; k++) {
-            const a = Math.floor(Math.random() * this.W), b = Math.floor(Math.random() * this.W);
-            if (a === b) continue;
-            const srcTop = this.board[a].slice().reverse().findIndex(c => c.type !== NodeType.EMPTY);
-            if (srcTop < 0) continue;
-            const ai = this.board[a].length - 1 - srcTop;
-            const bi = this.board[b].slice().reverse().findIndex(c => c.type !== NodeType.EMPTY);
-            const insert = bi < 0 ? 0 : this.board[b].length - 1 - bi + 1;
-            const cell = this.board[a][ai];
-            for (let r = this.board[a].length - 1; r > ai; r--) this.board[a][r] = this.board[a][r - 1];
-            this.board[a][ai] = {type: NodeType.EMPTY, color: null};
-            for (let r = this.board[b].length - 1; r > insert; r--) this.board[b][r] = this.board[b][r - 1];
-            this.board[b][insert] = cell;
-        }
-        
-        this.recalcPaletteRemaining();
-        this.renderPalette();
-        this.draw();
-        this.syncToGameState();
-    }
-
     syncToGameState(): void {
         // Update currentGameState from canvas
         const groups: GameStateNode[][] = [];


### PR DESCRIPTION
## Summary
- remove Randomize button from the board editor UI
- drop associated randomize event handler and editor method
- update documentation to mention only the Reset action

## Testing
- `npm test` (fails: Missing script "test")
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899f55bc548832abaf1186b48997ba8