### PR TITLE
Fix game state tube height using capacity

### DIFF
--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -141,7 +141,7 @@ class WaterSortApp {
         
         // Determine board dimensions from game state
         const cols = gameState.groups.length;
-        const rows = Math.max(...gameState.groups.map(g => g.length), 1);
+        const rows = gameState.capacity ?? Math.max(...gameState.groups.map(g => g.length), 1);
         
         // Update HTML inputs
         (document.getElementById('cols') as HTMLInputElement).value = cols.toString();
@@ -187,6 +187,7 @@ class WaterSortApp {
             }
             if (typeof data.rows === 'number') {
                 (document.getElementById('rows') as HTMLInputElement).value = data.rows.toString();
+                if (data.capacity === undefined) data.capacity = data.rows;
             }
             if (typeof data.mode === 'number') {
                 (document.getElementById('mode') as HTMLInputElement).value = data.mode.toString();

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -241,7 +241,7 @@ export class CanvasEditor {
             groups.push(group);
         }
         
-        this.currentGameState = { groups };
+        this.currentGameState = { groups, capacity: this.H };
         
         // Trigger custom event for game state update
         this.canvas.dispatchEvent(new CustomEvent<GameState>('gamestatechange', {
@@ -278,7 +278,7 @@ export class CanvasEditor {
             }
             groups.push(g);
         }
-        return { groups };
+        return { groups, capacity: this.H };
     }
 
     exportToJSON(mode: GameMode): string {

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -25,6 +25,7 @@ export interface GameStateNode {
 
 export interface GameState {
     groups: GameStateNode[][];
+    capacity?: number;
     undoCount?: number;
 }
 

--- a/src/ts/visualization.ts
+++ b/src/ts/visualization.ts
@@ -16,12 +16,12 @@ export class GameVisualizer {
 
         if (!gameState || !gameState.groups) return;
         
-        const maxHeight = Math.max(...gameState.groups.map(g => g.length), 1);
+        const capacity = gameState.capacity ?? Math.max(...gameState.groups.map(g => g.length), 1);
         
         for (let i = 0; i < gameState.groups.length; i++) {
             const tube = document.createElement('div');
             tube.className = 'tube';
-            tube.style.height = (maxHeight * 40 + 20) + 'px';
+            tube.style.height = (capacity * 40 + 20) + 'px';
             
             const group = gameState.groups[i];
             for (let j = 0; j < group.length; j++) {
@@ -165,6 +165,7 @@ export class SolutionVisualizer {
                     originalPos: [n.pos[0], n.pos[1]] as [number, number]
                 }))
             ),
+            capacity: game.capacity,
             undoCount: game.undoCount
         };
     }


### PR DESCRIPTION
## Summary
- Keep tube height consistent by basing it on puzzle capacity
- Propagate capacity through GameState, canvas editor, and import logic

## Testing
- `npm run type-check`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a10c00e8c832a84681c54f1d12e31