### PR TITLE
feat: add erase mode toggle for mobile

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -31,11 +31,12 @@
             <div style="margin-top:10px"><canvas id="grid" width="300" height="300"></canvas></div>
 
             <div class="panel" style="margin-top:12px">
-                <h3 style="display:flex;align-items:center;gap:8px">Color Palette <span class="muted" id="paletteHint">(left‑click paints, right‑click erases)</span></h3>
+                <h3 style="display:flex;align-items:center;gap:8px">Color Palette <span class="muted" id="paletteHint">(left‑click paints, right‑click erases, or enable Erase Mode on mobile)</span></h3>
                 <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 8px;">
                     <div class="legend" id="palette"></div>
                     <div>
                         <label>Colors <input id="numcolors" type="number" value="3" min="1" max="20"></label>
+                        <label style="margin-left:8px;"><input type="checkbox" id="eraseMode"> Erase Mode</label>
                     </div>
                 </div>
                 <div style="background:#0b1220; border:1px solid #1f2937; border-radius:12px; padding:12px; margin-top:8px; font-size:13px; opacity:0.8;">

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -14,6 +14,7 @@ export class CanvasEditor {
     activeColorIndex: number;
     currentGameState: GameState | null;
     isErasing: boolean;
+    eraseMode: boolean;
 
     constructor(canvasId: string, paletteId: string, options: {width?: number, height?: number} = {}) {
         this.canvas = document.getElementById(canvasId) as HTMLCanvasElement;
@@ -29,6 +30,7 @@ export class CanvasEditor {
         this.activeColorIndex = 0;
         this.currentGameState = null;
         this.isErasing = false;
+        this.eraseMode = false;
         
         this.setupEventListeners();
         this.rebuildPalette();
@@ -141,8 +143,13 @@ export class CanvasEditor {
 
     setupEventListeners(): void {
         this.canvas.addEventListener('contextmenu', (e: Event) => e.preventDefault());
+
+        document.getElementById('eraseMode')?.addEventListener('change', (e: Event) => {
+            this.eraseMode = (e.target as HTMLInputElement).checked;
+        });
+
         this.canvas.addEventListener('mousedown', (e: MouseEvent) => {
-            if (e.button === 2) {
+            if (e.button === 2 || (e.button === 0 && this.eraseMode)) {
                 const rect = this.canvas.getBoundingClientRect();
                 const cx = Math.floor((e.clientX - rect.left) / this.S);
                 const cy = this.H - 1 - Math.floor((e.clientY - rect.top) / this.S);


### PR DESCRIPTION
## Summary
- add Erase Mode toggle for board editor
- allow CanvasEditor to erase with left click when Erase Mode is active

## Testing
- `npm run type-check`
- `npm test` *(fails: Missing script: "test"*


------
https://chatgpt.com/codex/tasks/task_e_689a10e4e500832aad177cf0420f8aad