### PR TITLE
Allow horizontal scrolling of canvas on touch devices

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -26,7 +26,8 @@ html, body {
 }
 
 .board-canvas {
-    touch-action: none;
+    /* Allow horizontal scrolling while preventing vertical panning */
+    touch-action: pan-x;
 }
 
 .panel { 

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -143,7 +143,8 @@ export class CanvasEditor {
 
     setupEventListeners(): void {
         this.canvas.addEventListener('contextmenu', (e: Event) => e.preventDefault());
-        this.canvas.style.touchAction = 'none';
+        // Enable horizontal scrolling on touch devices
+        this.canvas.style.touchAction = 'pan-x';
 
         document.getElementById('eraseMode')?.addEventListener('change', (e: Event) => {
             this.eraseMode = (e.target as HTMLInputElement).checked;


### PR DESCRIPTION
## Summary
- Allow horizontal scrolling of the game board on touch devices
- Set `touch-action: pan-x` for the game canvas

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689a250d8254832ab2f290f7624d4d22