### PR TITLE
Restrict number inputs to valid ranges

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,8 +14,8 @@
         <div class="panel game-editor">
             <h3>🎨 Board Editor</h3>
             <div class="row">
-                <label>Columns <input id="cols" type="number" value="6" min="2" max="24"></label>
-                <label>Height <input id="rows" type="number" value="4" min="2" max="12"></label>
+                <label>Columns <input id="cols" type="number" inputmode="numeric" pattern="[0-9]*" value="6" min="3" max="30"></label>
+                <label>Height <input id="rows" type="number" inputmode="numeric" pattern="[0-9]*" value="4" min="2" max="20"></label>
                 <label>Mode
                     <select id="mode">
                         <option value="0">Normal (combo allowed)</option>
@@ -23,7 +23,7 @@
                         <option value="2">Queue output (FIFO)</option>
                     </select>
                 </label>
-                <label>Undo Count <input id="undo" type="number" value="5" min="0" max="20"></label>
+                <label>Undo Count <input id="undo" type="number" inputmode="numeric" pattern="[0-9]*" value="5" min="0" max="20"></label>
                 <button id="reset" class="secondary">Reset</button>
                 <button id="copyJson" class="secondary">Copy JSON</button>
                 <button id="pasteJson" class="secondary">Paste JSON</button>
@@ -37,7 +37,7 @@
                 <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 8px;">
                     <div class="legend" id="palette"></div>
                     <div>
-                        <label>Colors <input id="numcolors" type="number" value="3" min="1" max="20"></label>
+                        <label>Colors <input id="numcolors" type="number" inputmode="numeric" pattern="[0-9]*" value="3" min="2" max="30"></label>
                         <label style="margin-left:8px;"><input type="checkbox" id="eraseMode"> Erase Mode</label>
                     </div>
                 </div>
@@ -52,7 +52,7 @@
                     <input type="checkbox" id="debugMode"> Debug Mode
                 </label>
                 <label>
-                    Search Depth: <input type="number" id="searchDepth" value="8" min="1" max="15" style="width: 60px">
+                    Search Depth: <input type="number" id="searchDepth" inputmode="numeric" pattern="[0-9]*" value="5" min="0" max="10" style="width: 60px">
                 </label>
             </div>
         </div>

--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -15,21 +15,35 @@ class WaterSortApp {
         this.canvasEditor = new CanvasEditor('grid', 'palette');
         this.gameVisualizer = new GameVisualizer('gameVisualization');
         this.solutionVisualizer = new SolutionVisualizer('solutionResult');
-        
+
         this.setupEventListeners();
         this.initialize();
     }
 
+    private sanitizeNumberInput(input: HTMLInputElement): number {
+        input.value = input.value.replace(/[^0-9]/g, '');
+        const min = input.min !== '' ? parseInt(input.min, 10) : undefined;
+        const max = input.max !== '' ? parseInt(input.max, 10) : undefined;
+        let value = parseInt(input.value, 10);
+        if (isNaN(value)) value = min ?? 0;
+        if (min !== undefined && value < min) value = min;
+        if (max !== undefined && value > max) value = max;
+        input.value = value.toString();
+        return value;
+    }
+
     setupEventListeners(): void {
         // Canvas editor controls
-        (document.getElementById('cols') as HTMLInputElement).addEventListener('input', (e: Event) => {
-            const target = e.target as HTMLInputElement;
-            this.canvasEditor.resize(parseInt(target.value), undefined);
+        const colsInput = document.getElementById('cols') as HTMLInputElement;
+        colsInput.addEventListener('input', () => {
+            const value = this.sanitizeNumberInput(colsInput);
+            this.canvasEditor.resize(value, undefined);
         });
 
-        (document.getElementById('rows') as HTMLInputElement).addEventListener('input', (e: Event) => {
-            const target = e.target as HTMLInputElement;
-            this.canvasEditor.resize(undefined, parseInt(target.value));
+        const rowsInput = document.getElementById('rows') as HTMLInputElement;
+        rowsInput.addEventListener('input', () => {
+            const value = this.sanitizeNumberInput(rowsInput);
+            this.canvasEditor.resize(undefined, value);
         });
 
         document.getElementById('reset')!.addEventListener('click', () => {
@@ -54,9 +68,10 @@ class WaterSortApp {
             }
         });
 
-        (document.getElementById('numcolors') as HTMLInputElement).addEventListener('input', (e: Event) => {
-            const target = e.target as HTMLInputElement;
-            this.canvasEditor.rebuildPalette(parseInt(target.value));
+        const numColorsInput = document.getElementById('numcolors') as HTMLInputElement;
+        numColorsInput.addEventListener('input', () => {
+            const value = this.sanitizeNumberInput(numColorsInput);
+            this.canvasEditor.rebuildPalette(value);
         });
 
         document.getElementById('solveBtn')!.addEventListener('click', () => {
@@ -200,8 +215,8 @@ class WaterSortApp {
 
     solveGame(): void {
         const debugMode = (document.getElementById('debugMode') as HTMLInputElement).checked;
-        const searchDepth = parseInt((document.getElementById('searchDepth') as HTMLInputElement).value);
-        const undoCount = parseInt((document.getElementById('undo') as HTMLInputElement).value);
+        const searchDepth = this.sanitizeNumberInput(document.getElementById('searchDepth') as HTMLInputElement);
+        const undoCount = this.sanitizeNumberInput(document.getElementById('undo') as HTMLInputElement);
         const mode = Number((document.getElementById('mode') as HTMLInputElement).value) as GameMode;
         
         try {

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -47,12 +47,13 @@ export class CanvasEditor {
     rebuildPalette(colorCount?: number): void {
         const numColorsInput = document.getElementById('numcolors') as HTMLInputElement | null;
         const n = colorCount ?? (numColorsInput ? parseInt(numColorsInput.value) : 3);
+        const count = Math.max(2, Math.min(30, n));
         const base = [
             '#D98336', '#B33C38', '#0026C9', '#DC687D', '#01E5A6',
             '#55A3E3', '#707070', '#662F8C', '#68A90F', '#663300',
             '#3A5312', '#FFE643'
         ];
-        this.palette = Array.from({length: n}, (_, i) => ({
+        this.palette = Array.from({length: count}, (_, i) => ({
             color: new Color(base[i % base.length]),
             target: this.H,
             remaining: this.H
@@ -96,8 +97,8 @@ export class CanvasEditor {
     }
 
     resize(width?: number, height?: number): void {
-        if (width !== undefined) this.W = Math.max(2, Math.min(24, width));
-        if (height !== undefined) this.H = Math.max(2, Math.min(12, height));
+        if (width !== undefined) this.W = Math.max(3, Math.min(30, width));
+        if (height !== undefined) this.H = Math.max(2, Math.min(20, height));
         
         this.canvas.width = this.W * this.S;
         this.canvas.height = this.H * this.S;


### PR DESCRIPTION
## Summary
- Update board and palette inputs to new min/max limits
- Clamp canvas editor resizing and color palette generation to these bounds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689a25fb3e6c832a913bb4666605ee14