### PR TITLE
feat: enforce numeric keyboard for number inputs

### DIFF
--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -16,6 +16,7 @@ class WaterSortApp {
         this.gameVisualizer = new GameVisualizer('gameVisualization');
         this.solutionVisualizer = new SolutionVisualizer('solutionResult');
 
+        this.enforceNumericInput();
         this.setupEventListeners();
         this.initialize();
     }
@@ -30,6 +31,14 @@ class WaterSortApp {
         if (max !== undefined && value > max) value = max;
         input.value = value.toString();
         return value;
+    }
+
+    private enforceNumericInput(): void {
+        const numericInputs = document.querySelectorAll<HTMLInputElement>('input[type="number"]');
+        numericInputs.forEach(input => {
+            input.inputMode = 'numeric';
+            input.pattern = '[0-9]*';
+        });
     }
 
     setupEventListeners(): void {


### PR DESCRIPTION
## Summary
- ensure all numeric inputs request numeric keyboards on mobile by setting `inputmode` and `pattern` attributes programmatically

## Testing
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa8153848832a926ed5ae59b430a1