### PR TITLE
Use details elements for per-step state display

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -238,8 +238,7 @@ label {
     margin: 16px 0;
 }
 
-.steps li {
-    padding: 12px 16px;
+.step {
     margin: 4px 0;
     background-color: #0b1220;
     border: 1px solid #1f2937;
@@ -247,7 +246,17 @@ label {
     transition: all 0.2s;
 }
 
-.steps li:hover {
+.step summary {
+    padding: 12px 16px;
+    cursor: pointer;
+}
+
+.step-state {
+    padding: 12px 16px;
+    border-top: 1px solid #1f2937;
+}
+
+.step[open] {
     background-color: #1f2937;
     border-color: #3b82f6;
 }


### PR DESCRIPTION
## Summary
- Render solution steps as `<details>` elements so each step owns its state preview
- Add helper to visualize game state within each expanded step
- Style `.step` and `.step-state` for interactive toggling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_689b0de85764832aa17be27d4a786855