### PR TITLE
Fix missing color count in copied JSON

### DIFF
--- a/src/ts/app.ts
+++ b/src/ts/app.ts
@@ -205,7 +205,7 @@ class WaterSortApp {
 
     importFromJSON(json: string): void {
         try {
-            const data = JSON.parse(json) as GameState & {cols?: number; rows?: number; mode?: GameMode};
+            const data = JSON.parse(json) as GameState & {cols?: number; rows?: number; mode?: GameMode; colors?: number};
             if (typeof data.cols === 'number') {
                 (document.getElementById('cols') as HTMLInputElement).value = data.cols.toString();
             }
@@ -215,6 +215,10 @@ class WaterSortApp {
             }
             if (typeof data.mode === 'number') {
                 (document.getElementById('mode') as HTMLInputElement).value = data.mode.toString();
+            }
+            if (typeof data.colors === 'number') {
+                (document.getElementById('numcolors') as HTMLInputElement).value = data.colors.toString();
+                this.canvasEditor.rebuildPalette(data.colors);
             }
             this.setCanvasFromGameState(data);
         } catch (err) {

--- a/src/ts/canvas-editor.ts
+++ b/src/ts/canvas-editor.ts
@@ -341,6 +341,7 @@ export class CanvasEditor {
             cols: this.W,
             rows: this.H,
             mode,
+            colors: this.palette.length,
             groups: this.toSolverFormat().groups
         };
         return JSON.stringify(data);


### PR DESCRIPTION
## Summary
- include palette color count when exporting puzzle JSON
- rebuild palette using color count when importing JSON

## Testing
- `npm test` (fails: Missing script "test")
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689b1299a460832a9c2f80e48cfd5fa3